### PR TITLE
Add category filter on query params on searching

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,10 @@
       "!shared/config.ts",
       "!database/migrations/**.ts",
       "!**/**.e2e-spec.ts",
-      "!**/tests/utils/**"
+      "!**/tests/utils/**",
+      "!**/**.repository.ts",
+      "!**/**.dto.ts",
+      "!**/**.entity.ts"
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",

--- a/src/database/migrations/1657250259443-create-category-table.ts
+++ b/src/database/migrations/1657250259443-create-category-table.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class createCategoryTable1657250259443 implements MigrationInterface {
+  name = 'createCategoryTable1657250259443';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "categories" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "name" character varying NOT NULL, CONSTRAINT "UQ_8b0be371d28245da6e4f4b61878" UNIQUE ("name"), CONSTRAINT "PK_24dbc6126a28ff948da33e97d3b" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(`ALTER TABLE "products" ADD "categoryId" uuid`);
+    await queryRunner.query(
+      `ALTER TABLE "products" ADD CONSTRAINT "FK_ff56834e735fa78a15d0cf21926" FOREIGN KEY ("categoryId") REFERENCES "categories"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "products" DROP CONSTRAINT "FK_ff56834e735fa78a15d0cf21926"`,
+    );
+    await queryRunner.query(`ALTER TABLE "products" DROP COLUMN "categoryId"`);
+    await queryRunner.query(`DROP TABLE "categories"`);
+  }
+}

--- a/src/products/controllers/products.controller.ts
+++ b/src/products/controllers/products.controller.ts
@@ -1,15 +1,15 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { ProductsService } from '@products/services/products.service';
 import { Product } from '@products/entities/product.entity';
-import { Pagination } from '@main/shared/serializers/pagination.serializer';
-import { PaginationQueryDTO } from '@main/shared/dtos/pagination-query.dto';
+import { Pagination } from '@shared/serializers/pagination.serializer';
 import {
   ApiExtraModels,
   ApiInternalServerErrorResponse,
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
-import { ApiPagination } from '@main/shared/decorators/api-pagination.decorator';
+import { ApiPagination } from '@shared/decorators/api-pagination.decorator';
+import { ProductQueryDTO } from '@products/dtos/product-query.dto';
 
 @ApiTags('Products')
 @ApiExtraModels(Pagination, Product)
@@ -21,9 +21,7 @@ export class ProductsController {
   @ApiPagination(Product)
   @ApiInternalServerErrorResponse({ description: 'Unexpected error' })
   @Get()
-  async getAll(
-    @Query() query: PaginationQueryDTO,
-  ): Promise<Pagination<Product>> {
+  async getAll(@Query() query: ProductQueryDTO): Promise<Pagination<Product>> {
     return this.service.getAll(query);
   }
 }

--- a/src/products/dtos/product-query.dto.ts
+++ b/src/products/dtos/product-query.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaginationQueryDTO } from '@shared/dtos/pagination-query.dto';
+import { Transform, Type } from 'class-transformer';
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+export class ProductQueryDTO extends PaginationQueryDTO {
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @Type(() => String)
+  @Transform(({ value }) => value.split(','))
+  @ApiProperty({
+    description: 'Specify the name of the category',
+    example: ['Technology', 'Finance'],
+  })
+  readonly byCategories?: string[];
+}

--- a/src/products/entities/category.entity.ts
+++ b/src/products/entities/category.entity.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Column, Entity, OneToMany } from 'typeorm';
+
+import { Base } from '@shared/entities/base.entity';
+import { Product } from '@products/entities/product.entity';
+
+@Entity('categories')
+export class Category extends Base {
+  @ApiProperty({
+    description: 'Name associated with the category',
+    example: 'Technology',
+    type: String,
+  })
+  @Column({ type: 'varchar', unique: true, nullable: false })
+  readonly name: string;
+
+  @OneToMany(() => Product, (product) => product.category)
+  readonly products: Product[];
+
+  constructor(name: Category['name']) {
+    super();
+    this.name = name;
+  }
+}

--- a/src/products/entities/product.entity.ts
+++ b/src/products/entities/product.entity.ts
@@ -1,8 +1,9 @@
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, ManyToOne } from 'typeorm';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 import { Base } from '@shared/entities/base.entity';
 import { IProductProps } from '@products/interfaces/product.interface';
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Category } from '@products/entities/category.entity';
 
 @Entity('products')
 export class Product extends Base {
@@ -46,13 +47,19 @@ export class Product extends Base {
   @Column({ type: 'varchar', nullable: true })
   readonly image: string;
 
+  @ManyToOne(() => Category, (category) => category.products)
+  readonly category: Category;
+
   constructor(productProps: IProductProps) {
-    const { name, description, price, stock, image } = productProps;
     super();
-    this.name = name;
-    this.description = description;
-    this.price = price;
-    this.stock = stock;
-    this.image = image;
+    if (productProps) {
+      const { name, description, price, stock, image, category } = productProps;
+      this.name = name;
+      this.description = description;
+      this.price = price;
+      this.stock = stock;
+      this.image = image;
+      this.category = category;
+    }
   }
 }

--- a/src/products/interfaces/product.interface.ts
+++ b/src/products/interfaces/product.interface.ts
@@ -1,7 +1,10 @@
+import { Category } from '@products/entities/category.entity';
+
 export interface IProductProps {
   name: string;
   description: string;
   price: number;
   stock: number;
   image: string;
+  category: Category;
 }

--- a/src/products/services/products.service.ts
+++ b/src/products/services/products.service.ts
@@ -1,4 +1,3 @@
-import { PaginationQueryDTO } from '@main/shared/dtos/pagination-query.dto';
 import { Pagination } from '@main/shared/serializers/pagination.serializer';
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -6,6 +5,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Product } from '@products/entities/product.entity';
 import { GetAllProductsException } from '@products/exceptions/get-all-products.exception';
 import { ProductsRepository } from '@products/repositories/products.repository';
+import { ProductQueryDTO } from '@products/dtos/product-query.dto';
 
 @Injectable()
 export class ProductsService {
@@ -16,7 +16,7 @@ export class ProductsService {
     private readonly productRepository: ProductsRepository,
   ) {}
 
-  async getAll(query: PaginationQueryDTO): Promise<Pagination<Product>> {
+  async getAll(query: ProductQueryDTO): Promise<Pagination<Product>> {
     try {
       this.logger.log(`Attempting to find all products`);
       const products = await this.productRepository.findAll(query);

--- a/src/products/tests/controllers/products.controller.spec.ts
+++ b/src/products/tests/controllers/products.controller.spec.ts
@@ -1,11 +1,12 @@
-import { ProductsController } from '@main/products/controllers/products.controller';
-import { GetAllProductsException } from '@main/products/exceptions/get-all-products.exception';
-import { ProductsService } from '@main/products/services/products.service';
+import { Test } from '@nestjs/testing';
+
+import { ProductsController } from '@products/controllers/products.controller';
+import { GetAllProductsException } from '@products/exceptions/get-all-products.exception';
+import { ProductsService } from '@products/services/products.service';
 import {
   createFakePagination,
-  createFakePaginationQueryDTO,
-} from '@main/shared/tests/fakes/pagination.fake';
-import { Test } from '@nestjs/testing';
+  createFakeProductQueryDTO,
+} from '@shared/tests/fakes/pagination.fake';
 import { mockProductsService } from '@products/tests/mocks/products.service.mock';
 
 describe('ProductsController Unit Tests', () => {
@@ -28,7 +29,7 @@ describe('ProductsController Unit Tests', () => {
 
   describe('getAll', () => {
     it('should return five products', async () => {
-      const fakeQuery = createFakePaginationQueryDTO(5);
+      const fakeQuery = createFakeProductQueryDTO(5);
       const response = await productsController.getAll(fakeQuery);
 
       expect(response).toBeDefined();
@@ -49,7 +50,7 @@ describe('ProductsController Unit Tests', () => {
     });
 
     it('should return empty array if no product were found', async () => {
-      const fakeQuery = createFakePaginationQueryDTO();
+      const fakeQuery = createFakeProductQueryDTO();
       const fakePagination = createFakePagination([], fakeQuery);
       jest
         .spyOn(productService, 'getAll')
@@ -67,7 +68,7 @@ describe('ProductsController Unit Tests', () => {
     });
 
     it('should throw a GetAllProductsException if service fails', async () => {
-      const fakeQuery = createFakePaginationQueryDTO();
+      const fakeQuery = createFakeProductQueryDTO();
       jest.spyOn(productService, 'getAll').mockImplementationOnce(() => {
         throw new GetAllProductsException('');
       });

--- a/src/products/tests/fakes/categories.fake.ts
+++ b/src/products/tests/fakes/categories.fake.ts
@@ -1,0 +1,9 @@
+import { faker } from '@faker-js/faker';
+
+import { Category } from '@products/entities/category.entity';
+
+export const createFakeCategory = (): Category => {
+  const category = new Category(faker.name.firstName());
+  category.id = faker.datatype.uuid();
+  return category;
+};

--- a/src/products/tests/fakes/products.fake.ts
+++ b/src/products/tests/fakes/products.fake.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker';
 
 import { Product } from '@products/entities/product.entity';
 import { IProductProps } from '@products/interfaces/product.interface';
+import { createFakeCategory } from '@products/tests/fakes/categories.fake';
 
 export const createFakeProductEntity = (): Product => {
   const productProps: IProductProps = {
@@ -10,11 +11,14 @@ export const createFakeProductEntity = (): Product => {
     price: faker.datatype.number(1000000),
     stock: faker.datatype.number(100),
     image: faker.internet.url(),
+    category: createFakeCategory(),
   };
   return new Product(productProps);
 };
 
-export const createFakeProductEntityArray = (size = 5): Product[] => {
+export const createFakeProductEntityArray: (size?: number) => Product[] = (
+  size = 5,
+): Product[] => {
   const products: Product[] = [];
   for (let index = 0; index < size; index++) {
     products.push(createFakeProductEntity());

--- a/src/products/tests/products.e2e-spec.ts
+++ b/src/products/tests/products.e2e-spec.ts
@@ -1,23 +1,29 @@
 import * as request from 'supertest';
-import { HttpStatus, INestApplication } from '@nestjs/common';
+import { HttpStatus, INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { Product } from '@products/entities/product.entity';
 import { ProductModule } from '@products/product.module';
 import { createFakeProductEntityArray } from '@products/tests/fakes/products.fake';
 import { sharedTestingConfig } from '@shared/tests/utils/shared-testing.config';
 import { ProductsRepository } from '@products/repositories/products.repository';
+import { insertCategoriesWithRepository } from '@products/tests/utils/category.util';
+import { Category } from '@products/entities/category.entity';
+import { Pagination } from '@shared/serializers/pagination.serializer';
 
 describe('Products', () => {
   let app: INestApplication;
   let repository: ProductsRepository;
   let httpServer: any;
+  let insertCategories: (categories: Category[]) => Promise<any>[];
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     const module = await Test.createTestingModule({
       imports: [ProductModule, ...sharedTestingConfig],
     }).compile();
     app = module.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
     repository = module.get<ProductsRepository>(ProductsRepository);
+    insertCategories = insertCategoriesWithRepository(repository);
     await app.init();
     httpServer = app.getHttpServer();
   });
@@ -28,16 +34,19 @@ describe('Products', () => {
     it('should return empty array because there are no products', async () => {
       const response = await requestProducts();
       expect(response.statusCode).toEqual(HttpStatus.OK);
-      expect(response.body).toEqual([]);
+      expect(response.body.results).toEqual([]);
     });
 
     it('should return five products', async () => {
       const expectedProducts = createFakeProductEntityArray();
+      await Promise.all(
+        insertCategories(expectedProducts.map((product) => product.category)),
+      );
       await repository.insert(expectedProducts);
       const response = await requestProducts();
       expect(response.statusCode).toEqual(HttpStatus.OK);
-      expect(response.body.length).toBe(expectedProducts.length);
-      response.body.forEach((product: Product) => {
+      expect(response.body.results.length).toBe(expectedProducts.length);
+      response.body.results.forEach((product: Product) => {
         expect(product.name).toBeDefined();
         expect(product.description).toBeDefined();
         expect(product.price).toBeDefined();
@@ -47,9 +56,61 @@ describe('Products', () => {
         expect(product.updatedAt).toBeDefined();
       });
     });
+
+    it('should return expected limit products on expected page', async () => {
+      const expectedAmount = 20;
+      const expectedProducts = createFakeProductEntityArray(expectedAmount);
+      await Promise.all(
+        insertCategories(expectedProducts.map((product) => product.category)),
+      );
+      await repository.insert(expectedProducts);
+      const expectedLimit = 5;
+      const expectedPage = 3;
+      const response = await request(httpServer).get(
+        `/products?page=${expectedPage}&limit=${expectedLimit}`,
+      );
+      expect(response.statusCode).toEqual(HttpStatus.OK);
+      const body: Pagination<Product> = response.body;
+      expect(body.results.length).toBe(expectedLimit);
+      expect(body.actualPage).toBe(expectedPage);
+      expect(body.totalPages).toBe(Math.ceil(expectedAmount / expectedLimit));
+      expect(body.totalAmount).toBe(expectedAmount);
+      body.results.forEach((product: Product) => {
+        expect(product.name).toBeDefined();
+        expect(product.description).toBeDefined();
+        expect(product.price).toBeDefined();
+        expect(product.stock).toBeDefined();
+        expect(product.image).toBeDefined();
+        expect(product.createdAt).toBeDefined();
+        expect(product.updatedAt).toBeDefined();
+      });
+    });
+
+    it('should filter by category on products', async () => {
+      const productsToInsert = createFakeProductEntityArray();
+      const categories = productsToInsert.map((product) => product.category);
+      const [firstCategory, secondCategory] = categories;
+      await Promise.all(insertCategories(categories));
+      await repository.insert(productsToInsert);
+      const response = await request(httpServer).get(
+        `/products?byCategories=${firstCategory.name},${secondCategory.name}`,
+      );
+      expect(response.statusCode).toEqual(HttpStatus.OK);
+
+      const responseFirstCategoryLength = response.body.results.filter(
+        (product: Product) => product.category.name === firstCategory.name,
+      ).length;
+      expect(responseFirstCategoryLength).toBe(1);
+
+      const responseSecondCategoryLength = response.body.results.filter(
+        (product: Product) => product.category.name === secondCategory.name,
+      ).length;
+      expect(responseSecondCategoryLength).toBe(1);
+      expect(response.body.results.length).toBe(2);
+    });
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     const connection = repository.manager.connection;
     await connection.dropDatabase();
     await app.close();

--- a/src/products/tests/services/products.service.spec.ts
+++ b/src/products/tests/services/products.service.spec.ts
@@ -7,8 +7,8 @@ import { mockProductsRepository } from '@products/tests/mocks/products.repositor
 import { ProductsRepository } from '@products/repositories/products.repository';
 import {
   createFakePagination,
-  createFakePaginationQueryDTO,
-} from '@main/shared/tests/fakes/pagination.fake';
+  createFakeProductQueryDTO,
+} from '@shared/tests/fakes/pagination.fake';
 
 describe('ProductsService Unit Test', () => {
   let productsService: ProductsService;
@@ -35,7 +35,7 @@ describe('ProductsService Unit Test', () => {
 
   describe('getAll', () => {
     it('should return five product entities', async () => {
-      const fakeQuery = createFakePaginationQueryDTO(5);
+      const fakeQuery = createFakeProductQueryDTO(5);
       const response = await productsService.getAll(fakeQuery);
 
       expect(response).toBeDefined();
@@ -56,7 +56,7 @@ describe('ProductsService Unit Test', () => {
     });
 
     it('should return empty array if no products were found', async () => {
-      const fakeQuery = createFakePaginationQueryDTO();
+      const fakeQuery = createFakeProductQueryDTO();
       const fakePagination = createFakePagination([], fakeQuery);
       jest
         .spyOn(productsRepository, 'findAll')
@@ -74,7 +74,7 @@ describe('ProductsService Unit Test', () => {
     });
 
     it('should throw a GetAllProductsException if repository fails', async () => {
-      const fakeQuery = createFakePaginationQueryDTO();
+      const fakeQuery = createFakeProductQueryDTO();
       jest.spyOn(productsRepository, 'findAll').mockImplementationOnce(() => {
         throw new InternalServerErrorException();
       });

--- a/src/products/tests/utils/category.util.ts
+++ b/src/products/tests/utils/category.util.ts
@@ -1,0 +1,13 @@
+import { Repository } from 'typeorm';
+
+import { Product } from '@products/entities/product.entity';
+import { Category } from '@products/entities/category.entity';
+
+export const insertCategoriesWithRepository =
+  (repository: Repository<Product>) =>
+  (categories: Category[]): Promise<any>[] =>
+    categories.map((category) =>
+      repository.query(
+        `INSERT INTO categories (id, name) VALUES ('${category.id}', '${category.name}')`,
+      ),
+    );

--- a/src/shared/dtos/pagination-query.dto.ts
+++ b/src/shared/dtos/pagination-query.dto.ts
@@ -1,9 +1,11 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import { IsNumber, IsOptional } from 'class-validator';
 
 export class PaginationQueryDTO {
   @IsOptional()
   @IsNumber()
+  @Type(() => Number)
   @ApiPropertyOptional({
     type: Number,
     description: 'Set how many items should be returned',
@@ -13,6 +15,7 @@ export class PaginationQueryDTO {
 
   @IsNumber()
   @IsOptional()
+  @Type(() => Number)
   @ApiPropertyOptional({
     type: Number,
     description: 'Specify which page should be returned',

--- a/src/shared/entities/base.entity.ts
+++ b/src/shared/entities/base.entity.ts
@@ -7,7 +7,7 @@ import {
 
 export abstract class Base extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
-  id!: number;
+  id!: string;
 
   @CreateDateColumn({ name: 'created_at', nullable: false })
   createdAt!: Date;

--- a/src/shared/tests/fakes/pagination.fake.ts
+++ b/src/shared/tests/fakes/pagination.fake.ts
@@ -1,13 +1,16 @@
-import { PaginationQueryDTO } from '@main/shared/dtos/pagination-query.dto';
-import { Pagination } from '@main/shared/serializers/pagination.serializer';
+import { ProductQueryDTO } from '@products/dtos/product-query.dto';
+import { PaginationQueryDTO } from '@shared/dtos/pagination-query.dto';
+import { Pagination } from '@shared/serializers/pagination.serializer';
 
-export const createFakePaginationQueryDTO = (
+export const createFakeProductQueryDTO = (
   limit = 10,
   page = 1,
-): PaginationQueryDTO => {
+  byCategories?: string[],
+): ProductQueryDTO => {
   return {
     limit,
     page,
+    byCategories,
   };
 };
 

--- a/src/shared/tests/pagination.util.spec.ts
+++ b/src/shared/tests/pagination.util.spec.ts
@@ -1,6 +1,6 @@
 import { createFakeProductEntityArray } from '@main/products/tests/fakes/products.fake';
-import { PaginationUtils } from '../utils/pagination.util';
-import { createFakePaginationQueryDTO } from './fakes/pagination.fake';
+import { PaginationUtils } from '@shared/utils/pagination.util';
+import { createFakeProductQueryDTO } from '@shared/tests/fakes/pagination.fake';
 
 describe('PaginationUtils Unit Test', () => {
   describe('describePagination', () => {
@@ -18,7 +18,7 @@ describe('PaginationUtils Unit Test', () => {
 
   describe('createFindOptions', () => {
     it('should calculate take and skip values', () => {
-      const query = createFakePaginationQueryDTO(10, 4);
+      const query = createFakeProductQueryDTO(10, 4);
       const response = PaginationUtils.createFindOptions(query);
 
       expect(response).toBeDefined();

--- a/src/shared/utils/pagination.util.ts
+++ b/src/shared/utils/pagination.util.ts
@@ -1,9 +1,10 @@
 import { FindManyOptions } from 'typeorm';
-import { PaginationQueryDTO } from '../dtos/pagination-query.dto';
-import { Pagination } from '../serializers/pagination.serializer';
+
+import { PaginationQueryDTO } from '@shared/dtos/pagination-query.dto';
+import { Pagination } from '@shared/serializers/pagination.serializer';
 
 export class PaginationUtils {
-  static createFindOptions(query: PaginationQueryDTO): FindManyOptions {
+  static createFindOptions<T>(query: PaginationQueryDTO): FindManyOptions<T> {
     const take = query.limit;
     const page = query.page;
     const skip = (page - 1) * take;


### PR DESCRIPTION
## Pull request type

<!-- Please check the type of change your PR introduces: -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- There is not any information related to categories, so products don't belong to any.
- The suit test is checking coverage on `repository`, `dto` and `entity` files
- The pagination feature is failing because always use the value on the attributes as an string instead of a number

Issue Link: https://trello.com/c/JgWE9POP/8-as-a-user-i-should-be-able-to-filter-products-by-one-or-more-categories

## What is the new behavior?

- Created category table, it contains the name of the category.
- Add relation one to many with category on products table. 
- Add query params on the endpoint `GET /products` that list products to filter by categories creating a ProductQueryDTO. It will receive a property called `byCategories` with a string separated by commas with the category names
- Instead of using `findOptions` in the product repository to find the products, the `createQueryBuilder` method will join with categories and filter by the categories requested
- Update `PaginationQueryDTO` adding the annotation `@Type(() => Number)` to transform the string value received into a number to properly work
- Update `base.entity.ts` id type from number to string

### Unit tests
- Removed  `repository`, `dto` and `entity` files to be in the coverage testing report
- Add behaviour to create a category before insert products using the `query` API on the repository extracted from the test module for products

### e2e tests
- In the product e2e tests, when creating the test module for products, to the `app` object the `ValidationPipe` was added because the `ProductQueryDTO` transform the `byCategories` string into an array
- Updated tests to check for results in the body instead of directly check for the response on the body.
- Add test to check if the `GET /products` with the pagination is working
- Add test to check if the `GET /products` filtering by categories is working
- In the products e2e tests, change `beforeAll` and `afterAll` to `beforeEach` and `afterEach` to erase the database and create it again on each test

## Other information

- The change in the product repository was made because to join another table and make a WHERE statement in the query, the `findOptions` approach doesn't work.

## Preview

- Category Table
![image](https://user-images.githubusercontent.com/19678474/178794577-39a325a2-668b-4061-8851-711840c3c9f4.png)

- Product Table
![image](https://user-images.githubusercontent.com/19678474/178794687-17c95046-8ecc-486a-8d2a-e442dbcbb2a3.png)

